### PR TITLE
Add bucket region configuration info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ module.exports = {
   bucketConfig: { // optional - passed into S3.createBucket()
     Bucket: 'mys3bucket', // optional, else will attempt to use appName
     // ...
+    CreateBucketConfiguration: {
+      LocationConstraint: 'eu-west-1', // optional, note this region should match the application's target region (see http://blog.mikebabineau.com/2013/08/21/multi-region-gotcha-on-elastic-beanstalk/)
+    },
   },
   bucketTags: [ // optional
     {


### PR DESCRIPTION
You can't create a new application version from an S3 file hosted in a different region (according to [Mike Babineau](http://blog.mikebabineau.com/2013/08/21/multi-region-gotcha-on-elastic-beanstalk/)) which tripped me up. S3 throws an error `InvalidParameterCombination: Unable to download from S3 location (Bucket: <your-bucket-name>  Key: <filename>.zip). Reason: Moved Permanently` but this error is not displayed in the node-aws-beanstalk log so it appears to fail quietly, with the message `Create application version failed.`

Documenting this will help users to avoid this gotcha.
